### PR TITLE
Added chefspec tests for default recipe

### DIFF
--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -9,6 +9,14 @@ describe 'yum-osuosl::default' do
       it 'converges successfully' do
         expect { chef_run }.to_not raise_error
       end
+      it do
+        expect(chef_run).to add_yum_repository('osuosl').with(
+          repositoryid: 'osuosl',
+          description: 'OSUOSL repo $releasever - $basearch',
+          url: 'http://ftp.osuosl.org/pub/osl/repos/yum/$releasever/$basearch',
+          gpgkey: 'http://ftp.osuosl.org/pub/osl/repos/yum/RPM-GPG-KEY-osuosl'
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
All cookbooks need to have tests for their recipes. This cookbook only has one recipe, and that's the default recipe. This PR adds ChefSpec tests to the default recipe in this cookbook. To test, run rake.

Expected output:
```
cthalmann@blue:~/githubRepos/yum-osuosl$ rake
Running RuboCop...
Inspecting 7 files
.......

7 files inspected, no offenses detected
chef exec foodcritic --epic-fail any .

chef exec rspec

yum-osuosl::default
  centos 6.7
    converges successfully
    should add yum_repository "osuosl"
  centos 7.2.1511
    converges successfully
    should add yum_repository "osuosl"

Finished in 0.28597 seconds (files took 2.1 seconds to load)
4 examples, 0 failures


ChefSpec Coverage report generated...

  Total Resources:   1
  Touched Resources: 1
  Touch Coverage:    100.0%

You are awesome and so is your test coverage! Have a fantastic day!
```