### PR TITLE
Add AlmaLinux 9 support

### DIFF
--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -22,6 +22,11 @@ platforms:
       image: dokken/almalinux-8
       pid_one_command: /usr/lib/systemd/systemd
 
+  - name: almalinux-9
+    driver:
+      image: dokken/almalinux-9
+      pid_one_command: /usr/lib/systemd/systemd
+
   - name: centos-7
     driver:
       image: dokken/centos-7

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -18,6 +18,7 @@ provisioner:
 
 platforms:
   - name: almalinux-8
+  - name: almalinux-9
   - name: centos-7
 
 suites:

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,4 +9,5 @@ description      'Installs/Configures yum-osuosl'
 version          '2.0.2'
 
 supports         'almalinux', '~> 8.0'
+supports         'almalinux', '~> 9.0'
 supports         'centos', '~> 7.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,7 +20,10 @@
 yum_repository 'osuosl' do
   repositoryid 'osuosl'
   description 'OSUOSL repo $releasever - $basearch'
-  baseurl 'http://ftp.osuosl.org/pub/osl/repos/yum/$releasever/$basearch'
-  gpgkey 'http://ftp.osuosl.org/pub/osl/repos/yum/RPM-GPG-KEY-osuosl'
-  action :create
+  baseurl 'https://ftp.osuosl.org/pub/osl/repos/yum/$releasever/$basearch'
+  if node['platform_version'].to_i >= 9
+    gpgkey 'https://ftp.osuosl.org/pub/osl/repos/yum/RPM-GPG-KEY-osuosl-2024'
+  else
+    gpgkey 'https://ftp.osuosl.org/pub/osl/repos/yum/RPM-GPG-KEY-osuosl'
+  end
 end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -9,13 +9,26 @@ describe 'yum-osuosl::default' do
       it 'converges successfully' do
         expect { chef_run }.to_not raise_error
       end
-      it do
-        expect(chef_run).to create_yum_repository('osuosl').with(
-          repositoryid: 'osuosl',
-          description: 'OSUOSL repo $releasever - $basearch',
-          url: 'http://ftp.osuosl.org/pub/osl/repos/yum/$releasever/$basearch',
-          gpgkey: 'http://ftp.osuosl.org/pub/osl/repos/yum/RPM-GPG-KEY-osuosl'
-        )
+
+      case p
+      when ALMA_9
+        it do
+          expect(chef_run).to create_yum_repository('osuosl').with(
+            repositoryid: 'osuosl',
+            description: 'OSUOSL repo $releasever - $basearch',
+            url: 'https://ftp.osuosl.org/pub/osl/repos/yum/$releasever/$basearch',
+            gpgkey: 'https://ftp.osuosl.org/pub/osl/repos/yum/RPM-GPG-KEY-osuosl-2024'
+          )
+        end
+      else
+        it do
+          expect(chef_run).to create_yum_repository('osuosl').with(
+            repositoryid: 'osuosl',
+            description: 'OSUOSL repo $releasever - $basearch',
+            url: 'https://ftp.osuosl.org/pub/osl/repos/yum/$releasever/$basearch',
+            gpgkey: 'https://ftp.osuosl.org/pub/osl/repos/yum/RPM-GPG-KEY-osuosl'
+          )
+        end
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,11 @@
 require 'chefspec'
 require 'chefspec/berkshelf'
 
+ALMA_9 = {
+  platform: 'almalinux',
+  version: '9',
+}.freeze
+
 ALMA_8 = {
   platform: 'almalinux',
   version: '8',
@@ -13,6 +18,7 @@ CENTOS_7 = {
 
 ALL_PLATFORMS = [
   ALMA_8,
+  ALMA_9,
   CENTOS_7,
 ].freeze
 


### PR DESCRIPTION
- Switch to using https
- Use newer gpg key for AlmaLinux 9 that is signed with sha256 key

Signed-off-by: Lance Albertson <lance@osuosl.org>
